### PR TITLE
Fix: add missing brace in Ob1G5CollectionService.java

### DIFF
--- a/wear/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/services/Ob1G5CollectionService.java
@@ -409,7 +409,7 @@ public class Ob1G5CollectionService extends G5BaseService {
         }
     }
 
-    private void resetState() 
+    private void resetState() {
         UserError.Log.e(TAG, "Resetting sequence state to INIT");
         changeState(INIT);
     }


### PR DESCRIPTION
Moin! Got a compilation error when trying to build your dexcom-supporting wear component, seems a { was missing.